### PR TITLE
fix: Session restoration broken

### DIFF
--- a/src/api/actions.ts
+++ b/src/api/actions.ts
@@ -21,7 +21,7 @@ export const login = async (
   password: string,
   extras: Omit<
     LoginApiBody,
-    "email" | "password" | "unique_Id" | "client_name" | "reauth"
+    "email" | "password" | "unique_id" | "client_name" | "reauth"
   >,
 ): Promise<ApiSuccess<LoginApiResponse> | ApiError<LoginApiResponse>> => {
   const session = await buildIronSession();
@@ -43,7 +43,7 @@ export const login = async (
       email,
       password,
       ...extras,
-      unique_Id: session.client_id,
+      unique_id: session.client_id,
       client_name: process.env.CLIENT_NAME,
       reauth: session.reauth,
     }),
@@ -175,11 +175,14 @@ export const logout = async (): Promise<
   ApiSuccess<LogoutApiResponse> | ApiError<LogoutApiResponse>
 > => {
   const session = await buildIronSession();
-  if (session.state !== "TWO_FACTOR" || !session.account || !session.token) {
+
+  // Skip the logout if the session isn't active
+  if (session.state !== "LOGGED_IN" || !session.account || !session.token) {
     const oldId = session.client_id;
     session.destroy();
     session.client_id = oldId;
     session.state = "LOGGED_OUT";
+    session.reauth = false;
     await session.save();
 
     return {
@@ -358,7 +361,7 @@ export const register = async (
       password_confirm,
       country,
       ...extras,
-      unique_Id: session.client_id,
+      unique_id: session.client_id,
       client_name: process.env.CLIENT_NAME,
       reauth: session.reauth,
     }),

--- a/src/types/API.d.ts
+++ b/src/types/API.d.ts
@@ -24,7 +24,7 @@ type ApiError<T> = BaseResponse & {
 type LoginApiBody = {
   email: string;
   password: string;
-  unique_Id?: string;
+  unique_id?: string;
   client_type?: "amazon" | "android";
   client_name?: string;
   device_identifier?: string;


### PR DESCRIPTION
This PR addresses an issue where the 2FA flow is required each login. This is due to two things:

- `reauth` should only be set to true if the session was not destroyed (by an intentional logout)
- `client_id` should be a lowercase `i`, previously it was provided to the API as `client_Id`

Fixes #15